### PR TITLE
Update Get-VeeamProtection.psm1

### DIFF
--- a/functions/Get-VeeamProtection.psm1
+++ b/functions/Get-VeeamProtection.psm1
@@ -63,7 +63,7 @@ Process {
     foreach ($MyVm in $MyVms) {
         $MoRef = $MyVm.ExtensionData.MoRef.Value
         if ($VeeamVm = Find-VBRViEntity -Server $ViServer | Where-Object {$_.Reference -eq $MoRef}) {
-            [Array]$VmRestorePoints = $VbrReastorePoints | Where-Object {$_.InsideDir -match $MoRef}
+            [Array]$VmRestorePoints = $VbrReastorePoints | Where-Object {$_.InsideDir.Split("(,)") -eq $MoRef}
             if ($VmRestorePoints.count -gt 0) {$IsProtected = $true} else {$IsProtected = $false}
             $LastRestorePoint = $VmRestorePoints | Sort-Object CreationTime | Select-Object -Last 1
             $LastBackupJob = Get-VBRBackup | Where-Object {$_.Id -eq $LastRestorePoint.BackupId}


### PR DESCRIPTION
Edit RestorePoint Filter to fit exact MoRef

Within bigger environments you will have MoRefs like "vm-103" ,"vm-1031" and "vm-1032". 
So a match "vm-103" fits results all three examples. What will cause the Module to reportmore restorepoints for vm-103 then it actually has.
To overcome this issue I split the InsideDir String to only the MoRef and compare it with -eq and not -match.